### PR TITLE
Fixes #3 | Integrates TanStack Router + TanStack Query

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
   "dependencies": {
     "@reduxjs/toolkit": "^2.8.2",
     "@tailwindcss/vite": "^4.1.11",
+    "@tanstack/react-query": "^5.83.0",
+    "@tanstack/react-router": "^1.127.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hot-toast": "^2.5.2",
     "react-redux": "^9.2.0",
-    "react-router-dom": "^7.6.3",
     "recharts": "^3.1.0",
     "tailwindcss": "^4.1.11",
     "uuid": "^11.1.0",

--- a/router.tsx
+++ b/router.tsx
@@ -1,0 +1,39 @@
+import {
+    createRootRoute,
+    createRoute,
+    createRouter,
+    Outlet,
+} from '@tanstack/react-router';
+import DashboardPage from './src/pages/DashboardPage';
+import StrategyBuilder from './src/components/StrategyBuilder/StrategyBuilder';
+
+const rootRoute = createRootRoute({
+    component: () => <div><Outlet /></div>,
+});
+
+const homeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: DashboardPage,
+});
+
+const strategyRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/strategy',
+    component: StrategyBuilder,
+    validateSearch: (search: Record<string, unknown>) => {
+        return {
+            name: typeof search.name === 'string' ? search.name : '',
+        };
+    },
+});
+
+const routeTree = rootRoute.addChildren([homeRoute, strategyRoute]);
+
+export const router = createRouter({ routeTree });
+
+declare module '@tanstack/react-router' {
+    interface Register {
+        router: typeof router;
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,13 @@
-import {BrowserRouter as Router, Routes, Route} from 'react-router-dom';
-import {Toaster} from 'react-hot-toast';
-import DashboardPage from './pages/DashboardPage';
-import StrategyPage from './pages/StrategyPage';
+import { Toaster } from 'react-hot-toast';
+import React from "react";
 
-function App() {
-    return (
-        <>
-            <Toaster position="top-right" reverseOrder={false}></Toaster>
-            <Router>
-                <Routes>
-                    <Route path="/" element={<DashboardPage/>}/>
-                    <Route path="/strategy" element={<StrategyPage/>}/>
-                </Routes>
-            </Router>
-        </>
-    );
+function App({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <Toaster position="top-right" reverseOrder={false} />
+      {children}
+    </>
+  );
 }
 
 export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,14 +1,25 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App';
-import './index.css';
+import {RouterProvider} from '@tanstack/react-router';
 import {Provider} from 'react-redux';
 import {store} from './store';
+import {router} from '../router';
+import './index.css';
+
+import {QueryClient, QueryClientProvider} from "@tanstack/react-query";
+
+import App from './App';
+
+const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
         <Provider store={store}>
-            <App/>
+            <QueryClientProvider client={queryClient}>
+                <App>
+                    <RouterProvider router={router} />
+                </App>
+            </QueryClientProvider>
         </Provider>
     </React.StrictMode>
 );

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,36 +1,48 @@
+import toast from "react-hot-toast";
+
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 export async function simulateStrategy(data: any) {
     const res = await fetch(`${BASE_URL}/simulate`, {
         method: "POST",
-        headers: {"Content-Type": "application/json"},
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),
     });
-    return res.json();
+    return handleApiResponse(res, "Simulating strategy failed");
 }
 
 export async function saveStrategy(data: any) {
     const res = await fetch(`${BASE_URL}/strategies`, {
         method: "POST",
-        headers: {"Content-Type": "application/json"},
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),
     });
-    return res.json();
+    return handleApiResponse(res, "Saving strategy failed");
 }
 
 export async function loadStrategies() {
     const res = await fetch(`${BASE_URL}/strategies`);
-    return res.json();
+    return handleApiResponse(res, "Loading strategies failed");
 }
 
 export async function deleteStrategy(name: string) {
     const res = await fetch(`${BASE_URL}/strategies/${name}`, {
         method: "DELETE",
     });
-    return res.json();
+    return handleApiResponse(res, "Deleting strategy failed");
 }
 
 export async function loadStrategyByName(name: string) {
     const res = await fetch(`${BASE_URL}/strategies/${name}`);
+    return handleApiResponse(res, "Loading strategy by name failed");
+}
+
+async function handleApiResponse(res: Response, defaultErrMessage: string) {
+    if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        const errorMessage = err?.detail || defaultErrMessage;
+        toast.error(errorMessage);
+        throw new Error(errorMessage);
+    }
     return res.json();
 }

--- a/src/store/strategySlice.ts
+++ b/src/store/strategySlice.ts
@@ -7,7 +7,7 @@ type Asset = {
     weight: number;
 };
 
-type StrategyState = {
+export type StrategyState = {
     name: string;
     assets: Asset[];
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,10 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }
-  ]
+  ],
+  "compilerOptions": {
+    "strictNullChecks": true,
+    "strict": true,
+    "jsx": "react-jsx"
+  }
 }


### PR DESCRIPTION
This PR migrates routing and data-fetching logic to use **TanStack Router** and **TanStack Query**.

## Key Changes
* Replaced `react-router-dom` with `@tanstack/react-router`.
  * Navigation is now handled via `navigate({ to, search })`
  * Strategy name is derived from search params
* Integrated `@tanstack/react-query`
  * `useQuery` for fetching saved strategies
  * `useMutation` for saving, updating, deleting, and simulating strategies
  * `invalidateQueries` used to refresh strategy list after mutations
* Removed unused routing logic from `App.tsx`
* Cleaned up boilerplate `useEffect` and `localStorage` usage

## Known Issues
* Backend validation errors (e.g., invalid asset type or duplicate strategy name) are now thrown correctly not always displayed in the UI. Toast are used, but formatting and fallback messages may need improvement.

## Testing Notes
* Verified navigation and back/forward behavior
* Strategy creation, update, delete, and simulation flows tested end-to-end
* No breaking changes observed during manual testing